### PR TITLE
Generate api server URL from linkingUrl

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,3 +1,5 @@
+import { Constants } from 'expo'
+
 export default {
 
   MIN_CONFIRMATIONS: 3,
@@ -30,9 +32,7 @@ export default {
 
   SATOSHI: 0.00000001,
 
-  SERVICE: 'http://localhost:3000/',
-  // SERVICE: 'http://100.76.165.45:3000/',
-  // SERVICE: 'http://172.17.164.83:3000/',
+  SERVICE: Constants.linkingUrl.replace(/^\w+:\/\/([^:\/]+):\d+\/.*$/, 'http://$1:3000/'),
 
   STATE: {
     // -- Transactions


### PR DESCRIPTION
While in dev, once we have a prod server we can use
```
__dev__ ? Constants.linkingUrl.replace(...) : "prod_url"
```